### PR TITLE
feature: Support multiple language detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/ProfChaos/torrent-name-parser
 
 go 1.20
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/language.go
+++ b/language.go
@@ -13,7 +13,7 @@ func init() {
 	languageGeneral = regexp.MustCompile(`(?i)\b(?:RUS|NL|FLEMISH|GERMAN|DUBBED|FR(?:ENCH)?|Truefrench|VF(?:[FI])|VOST(?:(?:F(?:R)?)|A)?|SUBFRENCH|MULTi(?:Lang|-VF2)?|ITA(?:LIAN)?|(?:iTALiAN)|Eng)\b`)
 }
 
-func (p *parser) GetLanguage() []string {
+func (p *parser) GetLanguages() []string {
 	return p.FindStrings("languages", languageGeneral, FindStringsOptions{Handler: func(strs []string) []string {
 		lowerStrs := make([]string, len(strs))
 		for i, str := range strs {

--- a/language.go
+++ b/language.go
@@ -10,11 +10,16 @@ var (
 )
 
 func init() {
-	languageGeneral = regexp.MustCompile(`(?i)\b(?:RUS|NL|FLEMISH|GERMAN|DUBBED|FR(?:ENCH)?|Truefrench|VF(?:[FI])|VOST(?:(?:F(?:R)?)|A)?|SUBFRENCH|MULTi(?:Lang|-VF2)?|ITA(?:LIAN)?|(?:iTALiAN))\b`)
+	languageGeneral = regexp.MustCompile(`(?i)\b(?:RUS|NL|FLEMISH|GERMAN|DUBBED|FR(?:ENCH)?|Truefrench|VF(?:[FI])|VOST(?:(?:F(?:R)?)|A)?|SUBFRENCH|MULTi(?:Lang|-VF2)?|ITA(?:LIAN)?|(?:iTALiAN)|Eng)\b`)
 }
 
-func (p *parser) GetLanguage() string {
-	return p.FindString("language", languageGeneral, FindStringOptions{Handler: func(str string) string {
-		return strings.ToLower(str)
+func (p *parser) GetLanguage() []string {
+	return p.FindStrings("languages", languageGeneral, FindStringsOptions{Handler: func(strs []string) []string {
+		lowerStrs := make([]string, len(strs))
+		for i, str := range strs {
+			lowerStrs[i] = strings.ToLower(str)
+		}
+
+		return lowerStrs
 	}})
 }

--- a/parser.go
+++ b/parser.go
@@ -121,7 +121,7 @@ func (p *parser) Parse() (Torrent, error) {
 	torrent.Unrated = p.GetUnrated()
 	torrent.Hdr = p.GetHdr()
 	torrent.ColorDepth = p.GetColorDepth()
-	torrent.Languages = p.GetLanguage()
+	torrent.Languages = p.GetLanguages()
 
 	// Workaround for checking if episode is part of title
 	yearIndex, yearOk := p.MatchedIndicies["year"]

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,9 +1,10 @@
 package torrentparser
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParser_Parse(t *testing.T) {
@@ -90,7 +91,7 @@ func TestParser_Parse(t *testing.T) {
 				Season:      -1,
 				Title:       "Color Of Night",
 				Unrated:     true,
-				Language:    "vostfr",
+				Languages:   []string{"vostfr"},
 				Source:      "brrip",
 				Codec:       "x264",
 				ContentType: Movie,
@@ -122,7 +123,7 @@ func TestParser_Parse(t *testing.T) {
 				Title:       "Ecrit Dans Le Ciel",
 				Source:      "dvdrip",
 				Year:        1954,
-				Language:    "multi",
+				Languages:   []string{"multi"},
 				Codec:       "x264",
 				Audio:       "ac3",
 				Group:       "gismo65",
@@ -177,7 +178,7 @@ func TestParser_Parse(t *testing.T) {
 				Title:       "Desperation",
 				Source:      "dvd",
 				Year:        2006,
-				Language:    "multi",
+				Languages:   []string{"multi"},
 				Region:      "R9",
 				Group:       "TBW1973",
 				ContentType: Movie,
@@ -192,7 +193,7 @@ func TestParser_Parse(t *testing.T) {
 				Year:        1990,
 				Audio:       "dts",
 				Resolution:  "1080p",
-				Language:    "vfi",
+				Languages:   []string{"vfi"},
 				Codec:       "x265",
 				Group:       "HTG",
 				ContentType: Movie,
@@ -350,6 +351,20 @@ func TestParser_Parse(t *testing.T) {
 				Hdr:         true,
 			},
 		},
+		{
+			name: "The.Wizard.of.Oz.1939.4K.HDR.DV.2160p.BDRemux Ita Eng x265-NAHOM",
+			want: Torrent{
+				Title:       "The Wizard of Oz",
+				ContentType: Movie,
+				Year:        1939,
+				Resolution:  "4k",
+				Codec:       "x265",
+				Group:       "NAHOM",
+				Languages:   []string{"ita", "eng"},
+				Hdr:         true,
+				Season:      -1,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -358,9 +373,7 @@ func TestParser_Parse(t *testing.T) {
 				t.Errorf("Parser.Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Parser.Parse() = %+v, want %+v", fmt.Sprintf("%+v+", got), fmt.Sprintf("%+v+", tt.want))
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -395,7 +408,7 @@ func TestContentType(t *testing.T) {
 func TestTorrentScanAndValue(t *testing.T) {
 	var torrent Torrent
 
-	jsonStr := `{"title":"Pirates of the Caribbean Dead Mans Chest","alternativeTitle":"","contentType":0,"year":0,"resolution":"4k","extended":false,"unrated":false,"proper":false,"repack":false,"convert":false,"hardcoded":false,"retail":false,"remastered":false,"region":"","container":"mkv","source":"web-dl","codec":"hevc","audio":"dts-hd","group":"WATCHER","season":-1,"episode":0,"language":"","hdr":true,"colorDepth":"","date":""}`
+	jsonStr := `{"title":"Pirates of the Caribbean Dead Mans Chest","alternativeTitle":"","contentType":0,"year":0,"resolution":"4k","extended":false,"unrated":false,"proper":false,"repack":false,"convert":false,"hardcoded":false,"retail":false,"remastered":false,"region":"","container":"mkv","source":"web-dl","codec":"hevc","audio":"dts-hd","group":"WATCHER","season":-1,"episode":0,"languages":null,"hdr":true,"colorDepth":"","date":""}`
 
 	err := torrent.Scan(jsonStr)
 	if err != nil {
@@ -409,10 +422,7 @@ func TestTorrentScanAndValue(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	fmt.Println(str)
-	if str != jsonStr {
-		t.Error("Value not parsed")
-	}
+	assert.Equal(t, jsonStr, str)
 
 	err = torrent.Scan([]byte(`{"title":"Rogue One A Star Wars Story","content_type":"movie","year":2016,"resolution":"1080p","container":"mkv","source":"bluray","codec":"x264","audio":"dts","group":"D-Z0N3","season":-1}`))
 	if err != nil {


### PR DESCRIPTION
This PR adds support for extracting multiple languages from the provided Torrent name.

I am also experimenting with some other enhancements which will make use of these new `FindStrings` and `shouldAllReturnNil` methods.  I'll open some more PR's if they turn out to be useful.

PS, nice library; thanks!