### PR TITLE
feature: Remove parentheses around year

### DIFF
--- a/date.go
+++ b/date.go
@@ -11,8 +11,8 @@ var (
 )
 
 func init() {
-	dateDate = regexp.MustCompile("(?i)[0-9]{4}.[0-9]{2}.[0-9]{2}")
-	dateYear = regexp.MustCompile(`(?i)(?:\[|\b)(\d{4})(?:\]|\b)`)
+	dateDate = regexp.MustCompile(`(?i)[0-9]{4}.[0-9]{2}.[0-9]{2}`)
+	dateYear = regexp.MustCompile(`(?i)(?:\[|\(|\b)(\d{4})(?:\]|\)|\b)`)
 }
 
 func (p *parser) GetDate() string {

--- a/title_test.go
+++ b/title_test.go
@@ -28,6 +28,10 @@ func TestParser_GetTitle(t *testing.T) {
 			name: "Utøya 22. juli AKA U - 22 july [2018].mp4",
 			want: []string{"Utøya 22 juli", "U - 22 july"},
 		},
+		{
+			name: "The Wizard of Oz (1939) (2160p BluRay AI x265 HEVC 10bit DDP 5.1 Joy) [UTR]",
+			want: []string{"The Wizard of Oz"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Some releases have the year wrapped in parentheses, so add them to the date regex to correctly remove them.